### PR TITLE
fix: Prevent leak on color save

### DIFF
--- a/color_utils.c
+++ b/color_utils.c
@@ -3,20 +3,19 @@
 /*                                                        :::      ::::::::   */
 /*   color_utils.c                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hhurnik <hhurnik@student.42.fr>            +#+  +:+       +#+        */
+/*   By: zslowian <zslowian@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/30 18:40:48 by zslowian          #+#    #+#             */
-/*   Updated: 2025/08/20 18:09:23 by hhurnik          ###   ########.fr       */
+/*   Updated: 2025/08/20 23:16:11 by zslowian         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "cub3d.h"
 
-void	ft_store_rgb(int color_storage[3], char **color_values,
-			t_cub3d *data);
+bool	ft_store_rgb(int color_storage[3], char **color_values);
 bool	are_all_colors(t_cub3d *data);
 
-void	ft_store_rgb(int color_storage[3], char **color_values, t_cub3d *data)
+bool	ft_store_rgb(int color_storage[3], char **color_values)
 {
 	int	i;
 	int	color;
@@ -25,14 +24,13 @@ void	ft_store_rgb(int color_storage[3], char **color_values, t_cub3d *data)
 	while (++i < 3)
 	{
 		if (!color_values[i])
-			ft_error(COLOR, "ft_store_rgb - insufficient RGB color"
-				"values provided", data);
+			return (true);
 		color = ft_atoi((const char *)color_values[i]);
 		if (color < 0 || color > 255)
-			ft_error(COLOR, "ft_store_rgb"
-				"- RGB color values must be between 0 and 255", data);
+			return (true);
 		color_storage[i] = color;
 	}
+	return (false);
 }
 
 bool	are_all_colors(t_cub3d *data)

--- a/cub3d.h
+++ b/cub3d.h
@@ -6,7 +6,7 @@
 /*   By: zslowian <zslowian@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/16 22:02:02 by zslowian          #+#    #+#             */
-/*   Updated: 2025/08/20 22:54:35 by zslowian         ###   ########.fr       */
+/*   Updated: 2025/08/20 23:19:28 by zslowian         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -246,8 +246,7 @@ void					ft_copy_map_token_to_struct(char *map_line,
 void					ft_finish_parsing_checks(t_cub3d *data);
 
 // COLORS
-void					ft_store_rgb(int color_storage[3], char **color_values,
-							t_cub3d *data);
+bool					ft_store_rgb(int color_storage[3], char **color_values);
 bool					are_all_colors(t_cub3d *data);
 void					init_colors(t_cub3d *data);
 

--- a/parse.c
+++ b/parse.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parse.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hhurnik <hhurnik@student.42.fr>            +#+  +:+       +#+        */
+/*   By: zslowian <zslowian@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/19 17:50:18 by zslowian          #+#    #+#             */
-/*   Updated: 2025/08/20 18:12:39 by hhurnik          ###   ########.fr       */
+/*   Updated: 2025/08/20 23:16:32 by zslowian         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -103,25 +103,27 @@ static void	ft_save_color(t_cub3d *data, t_token *token)
 {
 	char	**color_values;
 	int		i;
+	bool	is_error;
 
 	i = 0;
+	is_error = false;
 	if (data->colors == NULL)
 		data->colors = ft_calloc(1, sizeof(t_colors));
 	if (data->colors == NULL)
 		ft_error(MEM_ERROR, "ft_save_color\n", data);
 	color_values = ft_split(token->value, ',');
 	if (token->data_id == F)
-		ft_store_rgb(data->colors->floor_color, color_values, data);
+		is_error = ft_store_rgb(data->colors->floor_color, color_values);
 	else if (token->data_id == C)
-		ft_store_rgb(data->colors->ceiling_color, color_values, data);
-	else
-		ft_error(ERROR_WHEN_PARSING, "ft_save_info\n", data);
+		is_error = ft_store_rgb(data->colors->ceiling_color, color_values);
 	while (color_values[i])
 	{
 		free(color_values[i]);
 		i++;
 	}
 	free(color_values);
+	if (is_error)
+		ft_error(COLOR, "check colors in the input file\n", data);
 }
 
 static void	ft_save_texture_file_name(t_cub3d *data, t_token *token)


### PR DESCRIPTION
This PR fixes a memory leak that occurred when color parsing failed by preventing early termination before cleanup. The key change is refactoring the `ft_store_rgb `function to return an error status instead of calling `ft_error `directly, allowing proper cleanup of allocated memory before error handling.

- Refactored `ft_store_rgb `to return boolean error status instead of calling `ft_error `directly
- Added proper cleanup of `color_values `array before error handling in `ft_save_color`
- Updated function signatures and removed unused `data `parameter
